### PR TITLE
Fix upstart script hanging on Ubuntu 14.04

### DIFF
--- a/files/ubuntu/radicale.conf
+++ b/files/ubuntu/radicale.conf
@@ -5,7 +5,6 @@ description     "Radicale - Simple calendar server"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-expect daemon
 respawn
 respawn limit 10 5
 
@@ -17,4 +16,4 @@ pre-start script
     fi
 end script
 
-exec /usr/bin/radicale -d
+exec /usr/bin/radicale -f


### PR DESCRIPTION
On Ubuntu 14.04, with radicale 0.8-1 installed. Upstart script hangs
when trying the stop the service (as well as when starting the service
again). To reproduce the bug, type "sudo stop radicale" once the
service has been started. The command will hang. This is a "classical"
issue, which is described there:
https://bugs.launchpad.net/upstart/+bug/406397

Basically, upstart tries to keep track of the process ID, but when the
process forks we must tell upstart how many time the process has
forked (by using one of the `expect fork` or `expect daemon`
stanza). However the most reliable way to allow upstart to follow the
process ID is to not fork at all, as explained in the upstart
documentation: http://upstart.ubuntu.com/cookbook/#expect

To cope with the issue, the best bay is to launch radicale in
foreground, by using the -f option.
