### PR TITLE
Fix wrong htpasswd file

### DIFF
--- a/templates/default/users.erb
+++ b/templates/default/users.erb
@@ -1,6 +1,3 @@
-# file managed by chef
-# local modifications will be overwritten
-
 <% @userlist.each do |user,password| -%>
 <%= user %>:<%= password %>
 <% end %>


### PR DESCRIPTION
htpasswd file was not generated properly. Radicale does not support
lines in such file that do not include the ':' character.
