### PR TITLE
Authentication section changed to auth

### DIFF
--- a/templates/default/config.erb
+++ b/templates/default/config.erb
@@ -32,7 +32,7 @@ request = utf-8
 # Encoding for storing local calendars
 stock = utf-8
 
-[acl]
+[auth]
 # Access method
 # Value: None | htpasswd | LDAP
 type = <%= node["radicale"]["acl"] %>


### PR DESCRIPTION
Since radicale 0.8 (commit 45afac5), the authentication section is
`auth` instead of `acl`.
