### PR TITLE
Fix filesystem_folder configuration option

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default["radicale"]["ldap_base"] = "ou=users,dc=example,dc=com"
 default["radicale"]["ldap_attribute"] = "uid"
 default["radicale"]["ldap_binddn"] = nil
 default["radicale"]["ldap_password"] = nil
-default["radicale"]["folder"] = "~/.config/radicale/calendars"
+default["radicale"]["filesystem_folder"] = "~/.config/radicale/collections"
 default["radicale"]["logging"]["config"] = "/etc/radicale/logging"
 default["radicale"]["logging"]["debug"] = "False"
 default["radicale"]["logging"]["full_env"] = "False"

--- a/templates/default/config.erb
+++ b/templates/default/config.erb
@@ -58,8 +58,8 @@ ldap_binddn = <%= node["radicale"]["ldap_binddn"] %>
 ldap_password = <%= node["radicale"]["ldap_password"] %>
 
 [storage]
-# Folder for storing local calendars, created if not present
-folder = <%= node["radicale"]["folder"] %>
+# Folder for storing local collections, created if not present
+filesystem_folder = <%= node["radicale"]["filesystem_folder"] %>
 
 [logging]
 # Logging configuration file


### PR DESCRIPTION
Since Radicale 0.7, the location where radicale stores its data is
configured through the `filesystem_folder` option versus the
`folder` option in the previous release (see commit 4299348).
